### PR TITLE
Prepare 0.1.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- _Nothing yet_
+
+## [0.1.0-rc.2] - 2025-12-25
+
 ### Added
 - `use SlackBot, otp_app: ...` now injects instance helper functions (`push/1`, `push_async/1`, `emit/1`, `config/0`) so downstream code can call `MyApp.SlackBot.push({...})` without repeating the module name at every callsite.
 - Expanded `SlackBot.TierRegistry` defaults to cover Slack's published tier list (including special cases like `chat.postMessage`) along with regression tests.
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 - Removed the implicit `SlackBot.*/*` arities that defaulted to the `SlackBot` module. Call `MyBot.push/1`, `MyBot.push_async/1`, `MyBot.emit/1`, or `MyBot.config/0` (the injected helpers), or keep using the explicit forms (`SlackBot.push(bot, request)`, etc.) when supervising bots under custom names.
+
 ### Fixed
 - Suppressed optional Igniter and Rewrite module warnings in `mix slack_bot_ws.install` when those helper dependencies are not present.
 - Avoid blocking the users cache sync worker during Slack rate limits by scheduling retries instead of sleeping.

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,8 @@ defmodule SlackBot.MixProject do
         "GitHub" => "https://github.com/dfeuerbach/slack_bot_ws",
         "Changelog" => "https://github.com/dfeuerbach/slack_bot_ws/blob/master/CHANGELOG.md"
       },
-      files: ~w(lib docs mix.exs README.md LICENSE CHANGELOG.md AGENTS.md)
+      files:
+        ~w(lib mix.exs README.md LICENSE CHANGELOG.md AGENTS.md docs/diagnostics.md docs/getting_started.md docs/rate_limiting.md docs/releasing.md docs/slackbot_design.md docs/slash_grammar.md docs/telemetry_dashboard.md)
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,17 +4,18 @@ defmodule SlackBot.MixProject do
   def project do
     [
       app: :slack_bot_ws,
-      version: "0.1.0-rc.1",
+      version: "0.1.0-rc.2",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/dfeuerbach/slack_bot_ws",
+      source_ref: "0.1.0-rc.2",
       description: description(),
       package: package(),
       deps: deps(),
       docs: [
         main: "readme",
-        source_ref: "master",
+        source_ref: "v0.1.0-rc.2",
         source_url: "https://github.com/dfeuerbach/slack_bot_ws",
         extras: [
           "README.md",

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule SlackBot.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/dfeuerbach/slack_bot_ws",
-      source_ref: "0.1.0-rc.2",
+      source_ref: "v0.1.0-rc.2",
       description: description(),
       package: package(),
       deps: deps(),


### PR DESCRIPTION
## Summary
- bump the package version/docs source refs to 0.1.0-rc.2
- trim the Hex package file list so large image assets stay out of the tarball
- roll the latest entries into a dated 0.1.0-rc.2 changelog section and reset Unreleased

## Verification
- mix deps.get
- mix compile --warnings-as-errors
- mix test
- mix docs
- mix format --check-formatted
- mix hex.user whoami
- mix hex.build